### PR TITLE
updates css to show footnote numbers

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -146,3 +146,12 @@ ul {
 .dot {
   color: var(--highlight-color);
 }
+
+.footnotes {
+  ol {
+    list-style: decimal;
+    li {
+      list-style: decimal;
+    }
+  }
+}

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -84,14 +84,10 @@ ul {
       margin-bottom: 10px;
       margin-left: 0;
       list-style-type: disc;
-      list-style-position: inside;
-      @include breakpoint('small') {
-        margin-left: 20px;
-      }
+      list-style-position: outside;
+      margin-left: 10px;
     }
-    @include breakpoint('small') {
-      margin-left: 20px;
-    }
+    margin-left: 10px;
   }
   a {
     text-decoration: underline;

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -83,7 +83,7 @@ ul {
       line-height: 20px;
       margin-bottom: 10px;
       margin-left: 0;
-      list-style-type: circle;
+      list-style-type: disc;
       list-style-position: inside;
       @include breakpoint('small') {
         margin-left: 20px;

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -77,11 +77,14 @@ ul {
     margin-top: 10px;
     margin-bottom: 20px;
     list-style: disc;
+    padding-left: 0;
     li {
       font-size: 18px;
       line-height: 20px;
       margin-bottom: 10px;
       margin-left: 0;
+      list-style-type: circle;
+      list-style-position: inside;
       @include breakpoint('small') {
         margin-left: 20px;
       }

--- a/exampleSite/archetypes/pages.md
+++ b/exampleSite/archetypes/pages.md
@@ -5,4 +5,5 @@ image: images/writer.jpeg
 menu:
   main:
     name: "About"
+math: false
 ---

--- a/exampleSite/archetypes/posts.md
+++ b/exampleSite/archetypes/posts.md
@@ -4,4 +4,5 @@ date: {{ .Date }}
 description: 'As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. '
 image: images/cctv.jpeg
 draft: true
+math: false
 ---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,8 @@
   <link rel="stylesheet" href="{{ ($style | minify | fingerprint).RelPermalink }}">
   {{ end }}
 
+  {{ if .Params.math }}{{ partial "katex.html" . }}{{ end }}
+
   {{ block "meta_tags" . }}
     {{ if .Params.description }}<meta name="description" content="{{ .Params.description }}"/>{{ end }}
     <meta property="og:title" content="{{ .Title }}"/>

--- a/layouts/partials/katex.html
+++ b/layouts/partials/katex.html
@@ -1,0 +1,19 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.3/dist/katex.min.css" integrity="sha384-KiWOvVjnN8qwAZbuQyWDIbfCLFhLXNETzBQjA/92pIowpC0d2O3nppDGQVgwd2nB" crossorigin="anonymous">
+
+<!-- The loading of KaTeX is deferred to speed up page rendering -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.3/dist/katex.min.js" integrity="sha384-0fdwu/T/EQMsQlrHCCHoH10pkPLlKA1jL5dFyUOvB3lfeT2540/2g6YgSi2BL14p" crossorigin="anonymous"></script>
+
+<!-- To automatically render math in text elements, include the auto-render extension: -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.3/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"
+    onload="renderMathInElement(document.body);"></script>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "$", right: "$", display: false}
+            ]
+        });
+    });
+</script>


### PR DESCRIPTION
Shows markdown footnote numbers.

Without numbering footnotes, its not clear where multi-paragraph footnotes begin and end.

Also the numbering helps show which footnote matches to which reference in the main content.

