### PR TITLE
footnotes show footnote numbers

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -146,3 +146,12 @@ ul {
 .dot {
   color: var(--highlight-color);
 }
+
+.footnotes {
+  ol {
+    list-style: decimal;
+    li {
+      list-style: decimal;
+    }
+  }
+}


### PR DESCRIPTION
The styling currently doesn't show numbers on footnotes.

This can be confusing because the references to the footnotes are numbered links.

This update to the styling handles numbering the footnotes.

This would close issue #8.