### PR TITLE
Allow all colour variables to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your b
   addDot = true
   addFrame = true
   highlightColor = '#7b16ff'
+  baseColor = "#ffffff"
+  baseOffsetColor = "#eaeaea"
+  highlightColor = "#7b16ff"
+  dotColor = "#7b16ff"
+  headingColor = "#1c1b1d"
+  textColor = "#4e5157"
 ```
 
 ### Google Analytics

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -155,7 +155,7 @@ ul {
 }
 
 .dot {
-  color: var(--highlight-color);
+  color: var(--dot-color);
 }
 
 .footnotes {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2,11 +2,12 @@
   --font-family-heading: 'Poppins', sans-serif;
   --font-family-paragraph: Helvetica, sans-serif;
   --font-family-monospace: monospace;
-  --base-color: #ffffff;
-  --base-offset-color: #eaeaea;
+  --base-color: {{ .Site.Params.baseColor | default "#ffffff" }};
+  --base-offset-color: {{ .Site.Params.baseOffsetColor | default "#eaeaea" }};
   --highlight-color: {{ .Site.Params.highlightColor | default "#7b16ff" }};
-  --heading-color: #1c1b1d;
-  --text-color: #4e5157;
+  --heading-color: {{ .Site.Params.headingColor | default "#1c1b1d" }};
+  --text-color: {{ .Site.Params.textColor | default "#4e5157" }};
+  --dot-color: {{ .Site.Params.dotColor | default "#7b16ff" }};
 }
 
 $breakpoints: (

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,6 +22,11 @@ pygmentsUseClasses = true
   addDot = true
   addFrame = true
   highlightColor = '#7b16ff'
+  baseColor = "#ffffff"
+  baseOffsetColor = "#eaeaea"
+  headingColor = "#1c1b1d"
+  textColor = "#4e5157"
+  dotColor = "#7b16ff"
 
 # markdown config settings https://gohugo.io/getting-started/configuration-markup/#goldmark
 [markup]


### PR DESCRIPTION
Only some of the css colour variables were configurable, this adds hugo config params for every one.

The dot and title colours are also now separately configurable.
This is something I needed myself. I don't think there's any harm in having it but if it's not necessary I can pull it out of this PR.

Please note: there is also an `--color-base-text` used on `blockquote p` but it's only read, never set. I chose to ignore it; it might not be used at all.