### PR TITLE
Add support for plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,23 @@ Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your b
 
 ### Google Analytics
 
-Add you google analytics ID to the `config.toml`
+Add your google analytics ID to the `config.toml`
 
 ```toml
 # config.toml
 [params]
   google_analytics_id="UA-132398315-1"
+```
+
+### Plausible Analytics
+
+Add your plausible analytics domain to the `config.toml`.
+This is `data-domain` in your [tracking script code](https://plausible.io/docs/plausible-script).
+
+```
+// config.toml
+[params]
+  plausible_analytics_domain = "barryhennessy.com"
 ```
 
 # Deploying to Netlify

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -58,6 +58,7 @@
   {{ end }}
 
   {{ partial "google-analytics.html" . }}
+  {{ partial "plausible-analytics.html" . }}
 
 </body>
 </html>

--- a/layouts/partials/plausible-analytics.html
+++ b/layouts/partials/plausible-analytics.html
@@ -1,0 +1,5 @@
+{{- if .Site.IsServer -}}
+  <!-- Dont add analytics to localhost -->
+{{ else if .Site.Params.plausible_analytics_domain  }}
+  <script defer data-domain="{{ .Site.Params.plausible_analytics_domain }}" src="https://plausible.io/js/plausible.js"></script>
+{{ end }}


### PR DESCRIPTION
This is something I needed for my own site, but could be useful to everyone. 

Plausible is an analytics provider that aims to provide straightforward analytics that comply with privacy regulations (in particular in the EU, but other countries are following suit).

Adding support is quite straightforward; all you need is the domain that you've activated tracking for. This has been added to the Hugo params and if set the `plausible-analytics.html` partial is included.

It can load alongside google analytics so both partials try to load (and do nothing if not configured to).

https://plausible.io/
https://plausible.io/docs/plausible-script