### PR TITLE
Remove date from Tags page

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone https://github.com/zerostaticthemes/hugo-winston-theme.git themes/hugo
 Copy the entire contents of the `mynewsite/themes/hugo-winston-theme/exampleSite/` folder to root folder of your Hugo site, ie `mynewsite/`. To copy the files using terminal, make sure you are still in the projects root, ie the `mynewsite` folder.
 
 ```
-cp -a themes/hugo-serif-theme/exampleSite/. .
+cp -a themes/hugo-winston-theme/exampleSite/. .
 ```
 
 **6. Run Hugo**

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,3 +42,8 @@ pygmentsUseClasses = true
     name = 'Home'
     url = '/'
     weight = 1
+  [[menu.main]]
+    name = "Tags"
+    identifier = "tags"
+    weight = 300
+    url = "/tags/"

--- a/exampleSite/content/posts/controls-the-past.md
+++ b/exampleSite/content/posts/controls-the-past.md
@@ -1,8 +1,12 @@
 ---
-title: Who controls the past controls the future. Who controls the present controls the past.
+title: Who controls the past controls the future. Who controls the present controls the past
 date: 2018-06-07
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. Then, with a movement which was as nearly as possible unconscious, he crumpled up the original message and any notes that he himself had made, and dropped them into the memory hole to be devoured by the flames."
 image: images/cctv2.jpeg
+tags:
+   - time
+   - writing 
+   - lorem 
 ---
 
 ## He moved over to the window

--- a/exampleSite/content/posts/destruction-of-words.md
+++ b/exampleSite/content/posts/destruction-of-words.md
@@ -3,6 +3,9 @@ title: It's a beautiful thing, the destruction of words
 date: 2018-10-30
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. "
 image: images/cctv.jpeg
+tags:
+   - writing 
+   - lorem 
 ---
 
 # He moved over to the window

--- a/exampleSite/content/posts/language-perfect.md
+++ b/exampleSite/content/posts/language-perfect.md
@@ -3,6 +3,9 @@ title: The revolution will be complete when the language is perfect
 date: 2019-08-07
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. Then, with a movement which was as nearly as possible unconscious, he crumpled up the original message and any notes that he himself had made, and dropped them into the memory hole to be devoured by the flames."
 image: images/cctv2.jpeg
+tags:
+   - writing 
+   - lorem 
 ---
 
 ## He moved over to the window

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -1,0 +1,15 @@
+{{ define "body_classes" }}page-default-list{{ end }}
+
+{{ define "main" }}
+  <div class="intro">
+    <h1>{{ .Title }}{{ if .Site.Params.addDot }}<span class="dot">.</span>{{ end }}</h1>
+    {{ if .Params.description }}<p>{{ .Params.description }}</p>{{ end }}
+  </div>
+  {{ .Content }}
+  {{ range.Pages }}
+    <div class="summary">
+      <h2 class="summary-title"><a href="{{ .RelPermalink }}">{{ .Title }}<span class="dot">.</span></a></h2>
+      <p class="summary-description">{{ .Params.description }}</p>
+    </div>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
Dates don't make a lot of sense for a tag list page. If a tag can belong to many posts, made on many days, then what does it mean to put, say, `October 19th 2022` beside tag `foo`?
Is that the first post, last one? Does it matter?

This simply takes the default list template and replaces the `summary` with a simplified version. I added the 'dot' because I think it looks nice and breaks the mononoty of an otherwise very bare page.

You could equally take this further and turn it into a full taxonomy page with sub-content etc. etc. This just takes a first step to making it usable.