### PR TITLE
Fix path for copying example content

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone https://github.com/zerostaticthemes/hugo-winston-theme.git themes/hugo
 Copy the entire contents of the `mynewsite/themes/hugo-winston-theme/exampleSite/` folder to root folder of your Hugo site, ie `mynewsite/`. To copy the files using terminal, make sure you are still in the projects root, ie the `mynewsite` folder.
 
 ```
-cp -a themes/hugo-serif-theme/exampleSite/. .
+cp -a themes/hugo-winston-theme/exampleSite/. .
 ```
 
 **6. Run Hugo**


### PR DESCRIPTION
Hello and thanks for providing this super cool theme!

There is a small error in the README.md guidelines, namely the path for copying example content in the __Installation -> Copy the example content__ section is wrong. Hence, this PR aims to address the aforementioned issue. 

