### PR TITLE
Add canonical link tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,6 +7,7 @@
   <title>{{ block "title" . }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="{{ .Site.BaseURL }}favicon.png">
+  <link rel="canonical" href="{{ .Permalink }}" />
 
   {{ if .Site.IsServer }}
   {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" true) }}


### PR DESCRIPTION
Google Search recommends to point out the canonical link to a page with a `<link rel="canonical" ...>` tag.

This helps to ensure that Google picks the right page, particularly when it's faced with http/https pages with the same content. If it's not sure it can choose not to index the page. This is surfaced in the search console.

Docs:
 - [Specify a canonical page](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#define-canonical)
 - [<link rel="canonical" ...>](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method)