### PR TITLE
Adding mechanism for supporting Disqus on blog posts

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,0 +1,17 @@
+<div id="disqus_thread"></div>
+<script type="text/javascript">
+
+(function() {
+    // Don't ever inject Disqus on localhost--it creates unwanted
+    // discussions from 'localhost:1313' on your Disqus account...
+    if (window.location.hostname == "localhost")
+        return;
+
+    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+    var disqus_shortname = '{{ .Site.DisqusShortname }}';
+    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+})();
+</script>
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="http://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -13,6 +13,7 @@
     </div>
     <div class="content">
       {{ .Content }}
+      {{ partial "disqus.html" . }}
     </div>
   </div>
 {{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -2,6 +2,7 @@ name = "Hugo Winston"
 license = "MIT"
 licenselink = "https://github.com/zerostaticthemes/hugo-winston/blob/master/LICENSE"
 description = "Hugo Winston is a bold minimal blogging theme"
+disqusShortname = ""
 
 homepage = "https://github.com/zerostaticthemes/hugo-winston-theme"
 demosite = "https://hugo-winston.netlify.app"


### PR DESCRIPTION
Disqus offers the best add-on tools for websites to increase engagement. It helps publishers power online discussions with comments and earn revenue with native advertising. 
Disqus is built-in in Hugo but I add a mechanism to only render discuss when the site is published online. 
Here's an example of how it will integrate with the theme.
![disqus](https://user-images.githubusercontent.com/45500540/196707892-29174094-3624-4cc9-af23-1db8d9e43957.png)
