### PR TITLE
fix missing post hero image alt attribute and author profile image alt…

### DIFF
--- a/exampleSite/content/posts/controls-the-past.md
+++ b/exampleSite/content/posts/controls-the-past.md
@@ -3,6 +3,7 @@ title: Who controls the past controls the future. Who controls the present contr
 date: 2018-06-07
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. Then, with a movement which was as nearly as possible unconscious, he crumpled up the original message and any notes that he himself had made, and dropped them into the memory hole to be devoured by the flames."
 image: images/cctv2.jpeg
+imageAltAttribute: CCTV Camera
 tags:
    - time
    - writing 

--- a/exampleSite/content/posts/destruction-of-words.md
+++ b/exampleSite/content/posts/destruction-of-words.md
@@ -3,6 +3,7 @@ title: It's a beautiful thing, the destruction of words
 date: 2018-10-30
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. "
 image: images/cctv.jpeg
+imageAltAttribute: CCTV Cameras
 tags:
    - writing 
    - lorem 

--- a/exampleSite/content/posts/language-perfect.md
+++ b/exampleSite/content/posts/language-perfect.md
@@ -3,6 +3,7 @@ title: The revolution will be complete when the language is perfect
 date: 2019-08-07
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. Then, with a movement which was as nearly as possible unconscious, he crumpled up the original message and any notes that he himself had made, and dropped them into the memory hole to be devoured by the flames."
 image: images/cctv2.jpeg
+imageAltAttribute: CCTV Camera
 tags:
    - writing 
    - lorem 

--- a/exampleSite/content/posts/sanity-not-statistical.md
+++ b/exampleSite/content/posts/sanity-not-statistical.md
@@ -3,6 +3,7 @@ title: Sanity is not statistical
 date: 2018-12-29
 description: 'Once again he glanced at his rival in the opposite cubicle. Something seemed to tell him with certainty that Tillotson was busy on the same job as himself. There was no way of knowing whose version would finally be adopted, but he felt a profound conviction that it would be his own'
 image: images/cctv2.jpeg
+imageAltAttribute: CCTV Camera
 ---
 
 ## There was no way of knowing whose version would finally be adopted

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 <div class="intro">
   <h1>{{ .Title }}{{ if .Site.Params.addDot }}<span class="dot">.</span>{{ end }}</h1>
   {{ if .Params.image }}
-  <img src="{{ .Params.image | relURL }}" />
+  <img alt="{{.Params.imageAltAttribute | default "Article hero image"}}" src="{{ .Params.image | relURL }}" />
   {{ end }}
 </div>
 

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,5 +1,5 @@
 <div class="author">
-  <img width="30" class="author-image" src="{{ .Site.Data.author.image | relURL }}" />
+  <img width="30" class="author-image" src="{{ .Site.Data.author.image | relURL }}" alt="{{ .Site.Data.author.name }}" />
   <span class="author-name">{{ .Site.Data.author.name }}</span>
   <span class="author-divider"></span>
   <span class="author-date">{{ dateFormat "January 2, 2006" .Date }}</span>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -8,7 +8,7 @@
     <div class="intro">
       <h1>{{ .Title }}{{ if .Site.Params.addDot }}<span class="dot">.</span>{{ end }}</h1>
       {{ if .Params.image }}
-      <img src="{{ .Params.image | relURL }}" />
+      <img alt="{{.Params.imageAltAttribute | default "Article hero image"}}" src="{{ .Params.image | relURL }}" />
       {{ end }}
     </div>
     <div class="content">


### PR DESCRIPTION
 Both the article hero image and the author profile image (when showAuthorOnPosts = true) alt attributes are missing and affecting PageSpeed Insights Accessibility and SEO metrics as shown in the screenshot attached.
![hugo-winston-theme-page-speed-insights](https://user-images.githubusercontent.com/17546550/233199440-7ec3fec7-807d-433d-bf2e-b043e719ba46.png)
