### PR TITLE
Allow custom fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your b
   showPostsOnHomepage = false
   addDot = true
   addFrame = true
+  fontFamilyHeading = "'Poppins', sans-serif"
+  fontFamilyParagraph = "'Helvetica', sans-serif"
+  fontFamilyMonospace = "monospace"
   highlightColor = '#7b16ff'
   baseColor = "#ffffff"
   baseOffsetColor = "#eaeaea"

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,7 +1,7 @@
 :root {
-  --font-family-heading: 'Poppins', sans-serif;
-  --font-family-paragraph: Helvetica, sans-serif;
-  --font-family-monospace: monospace;
+  --font-family-heading: {{ .Site.Params.fontFamilyHeading | default "'Poppins', sans-serif" }};
+  --font-family-paragraph: {{ .Site.Params.fontFamilyParagraph | default "'Helvetica', sans-serif" }};
+  --font-family-monospace: {{ .Site.Params.fontFamilyMonospace | default "monospace" }};
   --base-color: {{ .Site.Params.baseColor | default "#ffffff" }};
   --base-offset-color: {{ .Site.Params.baseOffsetColor | default "#eaeaea" }};
   --highlight-color: {{ .Site.Params.highlightColor | default "#7b16ff" }};


### PR DESCRIPTION
The theme already supports overriding the colour scheme. This patch adds support for overriding the fonts too.

To test it add the following entries for your `config.toml` file:

```
[params]
  ...
  fontFamilyHeading = "Comic Sans MS"
  fontFamilyParagraph = "Courier"
  fontFamilyMonospace = "Wingdings"
```

Much nicer, wouldn't you agree?