### PR TITLE
Move Google Fonts block out of head to defer loading.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,11 +33,6 @@
     {{ if .Site.Params.twitter_handle }}<meta name="twitter:creator" content="{{ .Site.Params.twitter_handle }}"/>{{ end }}
   {{ end }}
 
-  {{ if and .Site.Params.googleFontsUrl .Site.Params.enableGoogleFonts }}
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="{{ .Site.Params.googleFontsUrl }}" rel="stylesheet">
-  {{ end }}
-
   {{ partial "extend-head.html" . }}
 </head>
 
@@ -71,4 +66,9 @@
   {{ partial "extend-footer.html" . }}
 
 </body>
+
+{{ if and .Site.Params.googleFontsUrl .Site.Params.enableGoogleFonts }}
+<link rel="preconnect" href="https://fonts.gstatic.com">
+<link href="{{ .Site.Params.googleFontsUrl }}" rel="stylesheet">
+{{ end }}
 </html>


### PR DESCRIPTION
TL;DR - I recommended deferring the load of the font and CSS to improve First Contentful Paint and overall performance.

The default Google Font docs recommend you copy the font / css links into the <head>. Per Google PageInsights, this is probably the highest contributor to First Contentful Paint (on mobile 700ms). Moving the style and fonts links to the <html> tag and deferring their load enables a much faster First Contentful Paint by deferring the load. In the worst case (on my site at least) the resulting "flicker" for an extremely slow load of the CSS isn't too bad..probably because the default font isn't too wildly different than Poppins.