### PR TITLE
 Remove dates by not including them in metadata. Fixes Remove circle …

### DIFF
--- a/exampleSite/content/posts/language-perfect.md
+++ b/exampleSite/content/posts/language-perfect.md
@@ -1,6 +1,5 @@
 ---
 title: The revolution will be complete when the language is perfect
-date: 2019-08-07
 description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. Then, with a movement which was as nearly as possible unconscious, he crumpled up the original message and any notes that he himself had made, and dropped them into the memory hole to be devoured by the flames."
 image: images/cctv2.jpeg
 imageAltAttribute: CCTV Camera

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,7 +1,8 @@
 <div class="summary">
   {{ if .Site.Params.showAuthorOnPosts }}
     {{ partial "author.html" . }}
-  {{ else }}
+  {{ end }}
+  {{ if isset .Params "date" }}
     <div class="summary-date">{{ dateFormat "Jan 2, 2006" .Date }}</div>
   {{ end }}
   <h2 class="summary-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -2,7 +2,7 @@
   {{ if .Site.Params.showAuthorOnPosts }}
     {{ partial "author.html" . }}
   {{ end }}
-  {{ if isset .Params "date" }}
+  {{ if (and (isset .Params "date") (not .Site.Params.showAuthorOnPosts)) }}
     <div class="summary-date">{{ dateFormat "Jan 2, 2006" .Date }}</div>
   {{ end }}
   <h2 class="summary-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -2,5 +2,7 @@
   <img width="30" class="author-image" src="{{ .Site.Data.author.image | relURL }}" alt="{{ .Site.Data.author.name }}" />
   <span class="author-name">{{ .Site.Data.author.name }}</span>
   <span class="author-divider"></span>
-  <span class="author-date">{{ dateFormat "January 2, 2006" .Date }}</span>
+  {{ if isset .Params "date" }}
+    <span class="author-date">{{ dateFormat "January 2, 2006" .Date }}</span>
+  {{ end }}
 </div>


### PR DESCRIPTION
…from front page and dates from List #43

Remove dates from posts by removing the Date metadata from posts.

![image](https://github.com/zerostaticthemes/hugo-winston-theme/assets/21122180/aa75b3e7-e605-4078-ae96-5703fbda5a09)
````
---
title: The revolution will be complete when the language is perfect
description: "As soon as Winston had dealt with each of the messages, he clipped his speakwritten corrections to the appropriate copy of the Times and pushed them into the pneumatic tube. Then, with a movement which was as nearly as possible unconscious, he crumpled up the original message and any notes that he himself had made, and dropped them into the memory hole to be devoured by the flames."
image: images/cctv2.jpeg
imageAltAttribute: CCTV Camera
tags:
   - liberty 
   - surveillance
---
````