### PR TITLE
Fixed error: '.Site.IsServer' was deprecated in Hugo v0.120.0

### DIFF
--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,4 +1,4 @@
-{{- if .Site.IsServer -}}
+{{- if hugo.IsServer -}}
   <!-- Dont add Google analytics to localhost -->
 {{ else }}
   {{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}

--- a/layouts/partials/plausible-analytics.html
+++ b/layouts/partials/plausible-analytics.html
@@ -1,4 +1,4 @@
-{{- if .Site.IsServer -}}
+{{- if hugo.IsServer -}}
   <!-- Dont add analytics to localhost -->
 {{ else if .Site.Params.plausible_analytics_domain  }}
   <script defer data-domain="{{ .Site.Params.plausible_analytics_domain }}" src="https://plausible.io/js/plausible.js"></script>


### PR DESCRIPTION
Fixed error: '.Site.IsServer' was deprecated in Hugo v0.120.0, replaced with 'hugo.IsServer'